### PR TITLE
Stabilize keyboard input handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -203,7 +203,7 @@ impl App {
     }
 
     pub fn on_key(&mut self, key: KeyEvent) {
-        if matches!(key.kind, KeyEventKind::Repeat) {
+        if !matches!(key.kind, KeyEventKind::Press) {
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 use app::App;
-use crossterm::event::{self, Event as CEvent};
+use crossterm::event::{
+    self, Event as CEvent, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -34,7 +37,11 @@ fn main() -> Result<()> {
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::REPORT_EVENT_TYPES),
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
     Ok(terminal)
@@ -42,7 +49,11 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        PopKeyboardEnhancementFlags,
+        LeaveAlternateScreen,
+    )?;
     terminal.show_cursor()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- enable crossterm keyboard enhancement flags so repeat events are reported correctly
- ignore non-press key events in the app logic to avoid duplicate navigation actions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68cf3f1fba60832ea11a661e76ea8e5d