### PR TITLE
Fix duplicate crossterm imports and setup logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,16 +14,6 @@ use crossterm::event::{self, Event as CEvent};
 use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
-
-use crossterm::event::{self, Event as CEvent, PopKeyboardEnhancementFlags};
-#[cfg(not(windows))]
-use crossterm::event::{KeyboardEnhancementFlags, PushKeyboardEnhancementFlags};
-
-use crossterm::event::{
-    self, Event as CEvent, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,};
-
-
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -51,20 +41,6 @@ fn setup_terminal() -> Result<(Terminal<CrosstermBackend<Stdout>>, bool)> {
     let mut stdout = io::stdout();
     execute!(&mut stdout, EnterAlternateScreen)?;
     let keyboard_enhanced = try_enable_keyboard_enhancement(&mut stdout)?;
-
-
-
-    execute!(&mut stdout, EnterAlternateScreen)?;
-    let keyboard_enhanced = try_enable_keyboard_enhancement(&mut stdout)?;
-
-    execute!(
-        stdout,
-        EnterAlternateScreen,
-        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::REPORT_EVENT_TYPES),
-    )?;
-
-
-
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
     Ok((terminal, keyboard_enhanced))
@@ -79,22 +55,14 @@ fn restore_terminal(
     #[cfg(windows)]
     let _ = keyboard_enhanced;
     #[cfg(not(windows))]
-
     if keyboard_enhanced {
         execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags)?;
     }
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
 
-    execute!(
-        terminal.backend_mut(),
-        PopKeyboardEnhancementFlags,
-        LeaveAlternateScreen,
-    )?;
-
     terminal.show_cursor()?;
     Ok(())
 }
-
 
 #[cfg(windows)]
 fn try_enable_keyboard_enhancement(_: &mut Stdout) -> Result<bool> {
@@ -120,15 +88,7 @@ fn try_enable_keyboard_enhancement(stdout: &mut Stdout) -> Result<bool> {
     Ok(keyboard_enhanced)
 }
 
-
-#[cfg(not(windows))]
-
-
-#[cfg(not(windows))]
-
 #[cfg(windows)]
-
-
 fn keyboard_enhancement_unsupported(err: &std::io::Error) -> bool {
     use std::io::ErrorKind;
 
@@ -137,14 +97,10 @@ fn keyboard_enhancement_unsupported(err: &std::io::Error) -> bool {
             .to_string()
             .contains("Keyboard progressive enhancement not implemented")
 }
-
-
-
 #[cfg(not(windows))]
 fn keyboard_enhancement_unsupported(_: &std::io::Error) -> bool {
     false
 }
-
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<Stdout>>, app: &mut App) -> Result<()> {
     let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
## Summary
- remove redundant crossterm imports and repeated terminal setup calls
- ensure keyboard enhancement helpers are properly gated by their target platforms

## Testing
- cargo build

------
https://chatgpt.com/codex/tasks/task_b_68cf67baa92c832e9eecdc362413e064